### PR TITLE
Fix `AbsolutePath.basename` returning an invalid value.

### DIFF
--- a/Sources/Path/Path.swift
+++ b/Sources/Path/Path.swift
@@ -596,7 +596,7 @@ extension Path {
             // FIXME: This method seems too complicated; it should be simplified,
             //        if possible, and certainly optimized (using UTF8View).
             // Check for a special case of the root directory.
-            if string.first == "/" {
+            if ( (string.count == 1) ? string[string.startIndex] : nil) == "/" {
                 // Root directory, so the basename is a single path separator (the
                 // root directory is special in this regard).
                 return "/"

--- a/Sources/Path/Path.swift
+++ b/Sources/Path/Path.swift
@@ -596,7 +596,7 @@ extension Path {
             // FIXME: This method seems too complicated; it should be simplified,
             //        if possible, and certainly optimized (using UTF8View).
             // Check for a special case of the root directory.
-            if ( (string.count == 1) ? string[string.startIndex] : nil) == "/" {
+            if ((string.count == 1) ? string[string.startIndex] : nil) == "/" {
                 // Root directory, so the basename is a single path separator (the
                 // root directory is special in this regard).
                 return "/"


### PR DESCRIPTION
While forking the `AbsolutePath` and `RelativePath` utilities from Swift Tools Support, I made a mistake mimicking the logic [here](https://github.com/apple/swift-tools-support-core/blob/main/Sources/TSCBasic/Path.swift#L614), which caused `basename` to return an invalid value. This PR fixes it.