### PR TITLE
feat: add tests and cross-platform CI support

### DIFF
--- a/.github/workflows/Path.yml
+++ b/.github/workflows/Path.yml
@@ -22,15 +22,35 @@ env:
   TUIST_CONFIG_CLOUD_TOKEN: ${{ secrets.TUIST_CONFIG_CLOUD_TOKEN }}
 
 jobs:
+  spm_test:
+    name: SPM Build
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        swift-version:
+          - '6.0'
+        swift-compat-ver:
+          - '5'
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: SwiftyLab/setup-swift@latest
+      with:
+        swift-version: ${{ matrix.swift-version }}
+    - run: swift test --configuration debug -Xswiftc -swift-version -Xswiftc ${{ matrix.swift-compat-ver }}
   spm_build:
     name: SPM Build
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
-          - macOS-13
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
         swift-version:
-          - '5.9'
+          - '6.0'
         swift-compat-ver:
           - '5'
     runs-on: ${{ matrix.os }}
@@ -62,9 +82,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - macOS-13
+          - macOS-latest
         swift-version:
-          - '5.9'
+          - '6.0'
         swift-compat-ver:
           - '5'
     runs-on: ${{ matrix.os }}
@@ -81,9 +101,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - macOS-13
+          - macOS-latest
         swift-version:
-          - '5.9'
+          - '6.0'
         swift-compat-ver:
           - '5'
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ DerivedData/
 
 *.xcodeproj
 *.xcworkspace
+Derived/

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
             linkerSettings: [
                 .linkedLibrary("Pathcch", .when(platforms: [.windows])),
             ]
-        )
+        ),
+        .testTarget(name: "PathTests", dependencies: ["Path"])
     ]
 )

--- a/Project.swift
+++ b/Project.swift
@@ -1,7 +1,10 @@
 import ProjectDescription
 
 let project = Project(name: "Path", targets: [
-    .target(name: "Path", destinations: .macOS, product: .staticLibrary, bundleId: "io.tuist.Path", sources: [
+    .target(name: "Path", destinations: .macOS, product: .staticLibrary, bundleId: "dev.tuist.Path", sources: [
         "Sources/Path/**/*.swift",
     ]),
+    .target(name: "PathTests", destinations: .macOS, product: .unitTests, bundleId: "dev.tuist.PathTests", sources: [
+        "Tests/PathTests/**/*.swift"
+    ], dependencies: [.target(name: "Path")])
 ])

--- a/Project.swift
+++ b/Project.swift
@@ -5,6 +5,6 @@ let project = Project(name: "Path", targets: [
         "Sources/Path/**/*.swift",
     ]),
     .target(name: "PathTests", destinations: .macOS, product: .unitTests, bundleId: "dev.tuist.PathTests", sources: [
-        "Tests/PathTests/**/*.swift"
-    ], dependencies: [.target(name: "Path")])
+        "Tests/PathTests/**/*.swift",
+    ], dependencies: [.target(name: "Path")]),
 ])

--- a/Tests/PathTests/PathTests.swift
+++ b/Tests/PathTests/PathTests.swift
@@ -1,0 +1,1 @@
+import Testing

--- a/Tests/PathTests/PathTests.swift
+++ b/Tests/PathTests/PathTests.swift
@@ -1,1 +1,7 @@
 import Testing
+
+struct PathTests {
+    @Test func testExample() throws {
+        #expect(1 == 1)
+    }
+}

--- a/Tests/PathTests/PathTests.swift
+++ b/Tests/PathTests/PathTests.swift
@@ -1,7 +1,32 @@
 import Testing
+@testable import Path
 
 struct PathTests {
-    @Test func testExample() throws {
-        #expect(1 == 1)
-    }
+    #if os(Windows)
+        @Test func windows_path() throws {
+            #expect(try AbsolutePath(validating: "C:\\Users\\Test").dirname == "C:\\Users")
+        }
+    #endif
+
+    #if os(macOS) || os(Linux)
+        @Test func unix_path() throws {
+            #expect(try AbsolutePath(validating: "/usr/local/file.zip").dirname == "/usr/local")
+            #expect(try AbsolutePath(validating: "/usr/local/file.zip").basename == "file.zip")
+            #expect(try AbsolutePath(validating: "/usr/local/file.zip").extension == "zip")
+            #expect(try AbsolutePath(validating: "/usr/local/file.zip").basenameWithoutExt == "file")
+            #expect(try AbsolutePath(validating: "/usr/local/file.zip").parentDirectory.pathString == "/usr/local")
+            #expect(try AbsolutePath(validating: "/usr/local/file.zip").isRoot == false)
+            #expect(try AbsolutePath(validating: "/").isRoot == true)
+            #expect(try AbsolutePath(validating: "/usr/local/file.zip").components == ["/", "usr", "local", "file.zip"])
+            #expect(try AbsolutePath(validating: "/usr/local").appending(component: "bin").pathString == "/usr/local/bin")
+            #expect(
+                try AbsolutePath(validating: "/usr/local").appending(components: ["bin", "tuist"])
+                    .pathString == "/usr/local/bin/tuist"
+            )
+            #expect(
+                try AbsolutePath(validating: "/usr/local").appending(try RelativePath(validating: "bin/tuist"))
+                    .pathString == "/usr/local/bin/tuist"
+            )
+        }
+    #endif
 }


### PR DESCRIPTION
Add test target and initial test cases for Path

- Added a new test target "PathTests" in Package.swift and Project.swift
- Created test cases in PathTests.swift to verify path handling functionality
- Added platform-specific tests for both Windows and Unix-like systems
- Updated bundle identifier from io.tuist.Path to dev.tuist.Path

Enhance CI workflow and project configuration

- Added SPM test job to validate across Ubuntu, macOS, and Windows
- Updated runner versions to use latest available versions
- Added Derived/ to .gitignore
- Added test cases to verify path components, extensions, and directory operations

These changes establish a comprehensive test suite and ensure consistent behavior across platforms.